### PR TITLE
Remove unnecessary forward slashes in path names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed additional forward slashes in some file paths that break on Mac.
+
 ## [1.0.1-alpha.0] - 2024-02-09
 
 ### Fixed

--- a/src/common/Richtea.CodeAnalysis.CSharp.targets
+++ b/src/common/Richtea.CodeAnalysis.CSharp.targets
@@ -50,7 +50,7 @@
             <Output TaskParameter="Checksum"
                 PropertyName="ExistingStyleCopJsonChecksum" />
         </GenerateFileHash>
-        <GenerateFileHash InputFile="$(MSBuildThisFileDirectory)/StyleCop.json">
+        <GenerateFileHash InputFile="$(MSBuildThisFileDirectory)StyleCop.json">
             <Output TaskParameter="Checksum"
                 PropertyName="PackageStyleCopJsonChecksum" />
         </GenerateFileHash>

--- a/src/common/Richtea.CodeAnalysis.targets
+++ b/src/common/Richtea.CodeAnalysis.targets
@@ -82,7 +82,7 @@
             <Output TaskParameter="Checksum"
                 PropertyName="ExistingEditorConfigChecksum" />
         </GenerateFileHash>
-        <GenerateFileHash InputFile="$(MSBuildThisFileDirectory)/.editorconfig.root">
+        <GenerateFileHash InputFile="$(MSBuildThisFileDirectory).editorconfig.root">
             <Output TaskParameter="Checksum"
                 PropertyName="PackageEditorConfigChecksum" />
         </GenerateFileHash>

--- a/src/common/Richtea.Common.targets
+++ b/src/common/Richtea.Common.targets
@@ -17,7 +17,7 @@
     -->
     <Target Name="_RtInitializeDotSettingsCopy">
         <PropertyGroup>
-            <_PackageDotSettingsFile>$(MSBuildThisFileDirectory)/RtRecommendedPractices.DotSettings</_PackageDotSettingsFile>
+            <_PackageDotSettingsFile>$(MSBuildThisFileDirectory)RtRecommendedPractices.DotSettings</_PackageDotSettingsFile>
             <_TargetDotSettingsFile>$(RtRootDir)RtRecommendedPractices.DotSettings</_TargetDotSettingsFile>
             <_RtDotSettingsUpgradeRequired>true</_RtDotSettingsUpgradeRequired>
         </PropertyGroup>


### PR DESCRIPTION
`$(MSBuildThisFileDirectory)` must not have a forward slash after it, this is breaking on Mac.