### PR TITLE
Fix file capitalization of StyleCop.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix inconsistent capitalization of StyleCop.json, which breaks on Mac / Linux.
+
 ## [1.0.0] - 2024-02-09
 
 ### Added

--- a/src/common/Richtea.CodeAnalysis.CSharp.props
+++ b/src/common/Richtea.CodeAnalysis.CSharp.props
@@ -14,14 +14,14 @@
     </PropertyGroup>
 
     <!-- 
-        If StyleCop is enabled, include the root stylecop.json file unless one exists
+        If StyleCop is enabled, include the root StyleCop.json file unless one exists
         in the project folder.
     -->
     <ItemGroup Condition="'$(RtDisableStyleCop)' != 'true' And
-        !Exists('$(MSBuildProjectDirectory)stylecop.json') And
-        Exists('$(RtRootDir)stylecop.json')">
-        <AdditionalFiles Include="$(RtRootDir)stylecop.json"
-            Link="stylecop.json" />
+        !Exists('$(MSBuildProjectDirectory)StyleCop.json') And
+        Exists('$(RtRootDir)StyleCop.json')">
+        <AdditionalFiles Include="$(RtRootDir)StyleCop.json"
+            Link="StyleCop.json" />
     </ItemGroup>
 
 </Project>

--- a/src/common/StyleCop.json
+++ b/src/common/StyleCop.json
@@ -8,7 +8,7 @@
     "            NuGet package's version.",
     "  never   - Never modify this file, and don't issue any warnings about",
     "            any discrepancies (use this if you are managing it yourself).",
-    "  warn    - Do not modify any existing stylecop.json file, but create one if it doesn't",
+    "  warn    - Do not modify any existing StyleCop.json file, but create one if it doesn't",
     "            exist. If one exists and is different from the package version, issue a",
     "            build warning. NOTE: this is the default value if the property is not",
     "            specified.",


### PR DESCRIPTION
The capitalization of `StyleCop.json` was incorrect, causing build failures on Mac and Linux.